### PR TITLE
Fix comilation issue with GCC

### DIFF
--- a/src/entitygroup.cpp
+++ b/src/entitygroup.cpp
@@ -3,7 +3,7 @@
 EntityGroup::EntityGroup(int _id, QString _name)
     : id(_id),
       name(_name),
-      entities(new QList<unsigned long>()),
+      entities(new QList<unsigned long long>()),
       entityorder(new QMap<unsigned long, int>())
 {
 }

--- a/src/entitygroup.h
+++ b/src/entitygroup.h
@@ -17,7 +17,7 @@ public:
     // May need to keep additional names if we have several that are the same
 
     // This order is important for communicator rank ID
-    QList<unsigned long> * entities;
+    QList<unsigned long long> * entities;
     QMap<unsigned long, int> * entityorder;
 };
 


### PR DESCRIPTION
Hi Kate,

I came across this tool very recently. There are no open source (otf/otf2) trace visualisation tools out there and ravel is certainly helpful! Thanks for nice work!

I am trying to build latest master on OS-X with GCC-4.9 and see following error:

```bash
ravel/src/otf2importer.cpp:567:21: error: cannot convert 'QList<long long unsigned int>*' to 'QList<long unsigned int>*' in assignment
         t->entities = groupMap->value((comm.value())->group)->members;
                     ^
make[2]: *** [src/CMakeFiles/Ravel.dir/otf2importer.cpp.o] Error 1
```

I didn't look into all data structures but this PR was obvious fix (without looking into all details).

I will play with the tool and create issues if I see any errors.

